### PR TITLE
Add enum empty value for emptyDir configuration

### DIFF
--- a/helm-charts/templates/pulp-crd.yaml
+++ b/helm-charts/templates/pulp-crd.yaml
@@ -6129,6 +6129,7 @@ spec:
                 enum:
                 - ReadWriteMany
                 - ReadWriteOnce
+                - ""
                 type: string
               file_storage_size:
                 description: The size of the file storage; for example 100Gi. This


### PR DESCRIPTION
Hi, 

Without this value, it's not possible to deploy with emptyDir volume configuration, by example with s3 configuration.