### PR TITLE
Added more options to the chart:

### DIFF
--- a/helm-charts/templates/configmaps.yaml
+++ b/helm-charts/templates/configmaps.yaml
@@ -1,5 +1,9 @@
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pulp-operator-manager-config
+  namespace: {{ .Values.namespace }}
 data:
   controller_manager_config.yaml: |
     apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
@@ -23,7 +27,3 @@ data:
     # if you are doing or is intended to do any operation such as perform cleanups
     # after the manager stops then its usage might be unsafe.
     # leaderElectionReleaseOnCancel: true
-kind: ConfigMap
-metadata:
-  name: pulp-operator-manager-config
-  namespace: {{ .Values.namespace }}

--- a/helm-charts/templates/deployments.yaml
+++ b/helm-charts/templates/deployments.yaml
@@ -26,30 +26,24 @@ spec:
         control-plane: controller-manager
     spec:
       containers:
-      - args:
+      - name: kube-rbac-proxy
+        args:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
-        name: kube-rbac-proxy
+        image: {{ .Values.kubeProxy.image }}
         ports:
         - containerPort: 8443
           name: https
           protocol: TCP
         resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
+          {{- toYaml .Values.kubeProxy.resources | nindent 10 }}
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-      - args:
+          {{- toYaml .Values.kubeProxy.securityContext | nindent 10 }}
+      - name: manager
+        image: {{ .Values.image }}
+        args:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
@@ -59,25 +53,23 @@ spec:
         - /manager
         env:
         - name: RELATED_IMAGE_PULP
-          value: quay.io/pulp/pulp-minimal:stable
+          value: {{ .Values.operator.relatedImages.pulp }}
         - name: RELATED_IMAGE_PULP_WEB
-          value: quay.io/pulp/pulp-web:stable
+          value: {{ .Values.operator.relatedImages.pulpWeb }}
         - name: RELATED_IMAGE_PULP_REDIS
-          value: docker.io/library/redis:latest
+          value: {{ .Values.operator.relatedImages.redis }}
         - name: RELATED_IMAGE_PULP_POSTGRES
-          value: docker.io/library/postgres:13
+          value: {{ .Values.operator.relatedImages.postgres }}
         - name: WATCH_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: {{ .Values.image }}
         livenessProbe:
           httpGet:
             path: /healthz
             port: 8081
           initialDelaySeconds: 15
           periodSeconds: 20
-        name: manager
         readinessProbe:
           httpGet:
             path: /readyz
@@ -85,20 +77,14 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 10m
-            memory: 64Mi
+          {{- toYaml .Values.operator.resources | nindent 10 }}
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
+          {{- toYaml .Values.operator.securityContext | nindent 10 }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-      - name: redhat-operators-pull-secret
+      {{ toYaml . | nindent 6 | trim }}
+      {{- end }}
       securityContext:
-        runAsNonRoot: true
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       serviceAccountName: pulp-operator-controller-manager
       terminationGracePeriodSeconds: 10

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -2,5 +2,46 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Might want to be moved to under `.operator`, but left for backwards compatibility.
 image: quay.io/pulp/pulp-operator:v1.0.0-beta.3
 namespace: pulp
+
+podSecurityContext:
+  runAsNonRoot: true
+
+imagePullSecrets:
+- name: redhat-operators-pull-secret
+
+operator:
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+  relatedImages:
+    pulp: quay.io/pulp/pulp-minimal:stable
+    pulpWeb: quay.io/pulp/pulp-web:stable
+    redis: docker.io/library/redis:latest
+    postgres: docker.io/library/postgres:13
+
+kubeProxy:
+  image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi


### PR DESCRIPTION
* Added ability to change `securityContext` settings
* Added ability to change `resources` for both the `operator` and `kube-rbac-proxy`
* Added ability to specify `imagePullSecrets`, defaults to Openshift/OKD
* Added ability to change `relatedImages` for pulp. pulp-web, redis, and postgresql