### PR TITLE
Basic templating for k8s resources names

### DIFF
--- a/helm-charts/templates/_helpers.tpl
+++ b/helm-charts/templates/_helpers.tpl
@@ -1,0 +1,17 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "pulp-operator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm-charts/templates/configmaps.yaml
+++ b/helm-charts/templates/configmaps.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: pulp-operator-manager-config
+  name: {{ include "pulp-operator.fullname" . }}-manager-config
   namespace: {{ .Values.namespace }}
 data:
   controller_manager_config.yaml: |

--- a/helm-charts/templates/deployments.yaml
+++ b/helm-charts/templates/deployments.yaml
@@ -4,10 +4,10 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: operator
-    app.kubernetes.io/name: pulp-operator
+    app.kubernetes.io/name: {{ .Chart.Name }}
     control-plane: controller-manager
     owner: pulp-dev
-  name: pulp-operator-controller-manager
+  name: {{ include "pulp-operator.fullname" . }}-controller-manager
   namespace: {{ .Values.namespace }}
 spec:
   replicas: 1
@@ -22,7 +22,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         app.kubernetes.io/component: operator
-        app.kubernetes.io/name: pulp-operator
+        app.kubernetes.io/name: {{ .Chart.Name }}
         control-plane: controller-manager
     spec:
       containers:
@@ -86,5 +86,5 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      serviceAccountName: pulp-operator-controller-manager
+      serviceAccountName: {{ include "pulp-operator.fullname" . }}-controller-manager
       terminationGracePeriodSeconds: 10

--- a/helm-charts/templates/roles.yaml
+++ b/helm-charts/templates/roles.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: pulp-operator-leader-election-role
+  name: {{ include "pulp-operator.fullname" . }}-leader-election-role
   namespace: {{ .Values.namespace }}
 rules:
 - apiGroups:
@@ -41,7 +41,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: pulp-operator-manager-role
+  name: {{ include "pulp-operator.fullname" . }}-manager-role
   namespace: {{ .Values.namespace }}
 rules:
 - apiGroups:
@@ -255,7 +255,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: pulp-operator-metrics-reader
+  name: {{ include "pulp-operator.fullname" . }}-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -265,7 +265,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: pulp-operator-proxy-role
+  name: {{ include "pulp-operator.fullname" . }}-proxy-role
 rules:
 - apiGroups:
   - authentication.k8s.io
@@ -283,55 +283,55 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: pulp-operator-leader-election-rolebinding
+  name: {{ include "pulp-operator.fullname" . }}-leader-election-rolebinding
   namespace: {{ .Values.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: pulp-operator-leader-election-role
+  name: {{ include "pulp-operator.fullname" . }}-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: pulp-operator-controller-manager
+  name: {{ include "pulp-operator.fullname" . }}-controller-manager
   namespace: {{ .Values.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: pulp-operator-manager-rolebinding
+  name: {{ include "pulp-operator.fullname" . }}-manager-rolebinding
   namespace: {{ .Values.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: pulp-operator-manager-role
+  name: {{ include "pulp-operator.fullname" . }}-manager-role
 subjects:
 - kind: ServiceAccount
-  name: pulp-operator-controller-manager
+  name: {{ include "pulp-operator.fullname" . }}-controller-manager
   namespace: {{ .Values.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: pulp-operator-manager-rolebinding
+  name: {{ include "pulp-operator.fullname" . }}-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: pulp-operator-controller-manager
+  name: {{ include "pulp-operator.fullname" . }}-controller-manager
   namespace: {{ .Values.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: pulp-operator-proxy-rolebinding
+  name: {{ include "pulp-operator.fullname" . }}-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: pulp-operator-proxy-role
+  name: {{ include "pulp-operator.fullname" . }}-proxy-role
 subjects:
 - kind: ServiceAccount
-  name: pulp-operator-controller-manager
+  name: {{ include "pulp-operator.fullname" . }}-controller-manager
   namespace: {{ .Values.namespace }}
 
 
@@ -343,7 +343,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: pulp-operator-manager-role-tmp
+  name: {{ include "pulp-operator.fullname" . }}-manager-role-tmp
 rules:
 - apiGroups:
   - config.openshift.io
@@ -365,12 +365,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: pulp-operator-manager-rolebinding-tmp
+  name: {{ include "pulp-operator.fullname" . }}-manager-rolebinding-tmp
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: pulp-operator-manager-role-tmp
+  name: {{ include "pulp-operator.fullname" . }}-manager-role-tmp
 subjects:
 - kind: ServiceAccount
-  name: pulp-operator-controller-manager
+  name: {{ include "pulp-operator.fullname" . }}-controller-manager
   namespace: {{ .Values.namespace }}

--- a/helm-charts/templates/serviceaccounts.yaml
+++ b/helm-charts/templates/serviceaccounts.yaml
@@ -2,5 +2,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: pulp-operator-controller-manager
+  name: {{ include "pulp-operator.fullname" . }}-controller-manager
   namespace: {{ .Values.namespace }}

--- a/helm-charts/templates/services.yaml
+++ b/helm-charts/templates/services.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   labels:
     control-plane: controller-manager
-  name: pulp-operator-controller-manager-metrics-service
+  name: {{ include "pulp-operator.fullname" . }}-controller-manager-metrics-service
   namespace: {{ .Values.namespace }}
 spec:
   ports:

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Overrides for generated resource names to the previous value
+fullnameOverride: pulp-operator
+
 # Might want to be moved to under `.operator`, but left for backwards compatibility.
 image: quay.io/pulp/pulp-operator:v1.0.0-beta.4
 namespace: pulp


### PR DESCRIPTION
Solves #27

This PR adds a very standard templating name for the Kubernetes resources, which enables (together with #31) the possibility of running more than one instance of the operator.

Also, this sets `fullnameOverride: pulp-operator` in `values.yaml` for backward compatibility with previous deployments. This way, the default generated name will be the same as the one that was hardcoded before.

**Note**: Not all the templated resources are  used (the configmap, some clusterroles) but that is a conversation for a different time :)